### PR TITLE
Persist operators in server data

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,13 +39,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "520kB",
                   "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all"

--- a/server/db.json
+++ b/server/db.json
@@ -57,5 +57,31 @@
     { "id": 1, "title": "Revenue", "period": "This month", "kpi": 12500, "trend": 12 },
     { "id": 2, "title": "Occupancy", "period": "This week", "kpi": 78, "trend": 5 },
     { "id": 3, "title": "Incidents", "period": "This week", "kpi": 3, "trend": -8 }
+  ],
+  "operators": [
+    {
+      "id": 1,
+      "name": "Ethan Harper",
+      "email": "ethan.harper@example.com",
+      "role": "admin",
+      "status": "active",
+      "lastActiveKey": "CLIENTS.OPERATORS.LAST_ACTIVE.DAYS_2"
+    },
+    {
+      "id": 2,
+      "name": "Olivia Bennett",
+      "email": "olivia.bennett@example.com",
+      "role": "operator",
+      "status": "active",
+      "lastActiveKey": "CLIENTS.OPERATORS.LAST_ACTIVE.DAY_1"
+    },
+    {
+      "id": 3,
+      "name": "Noah Carter",
+      "email": "noah.carter@example.com",
+      "role": "operator",
+      "status": "inactive",
+      "lastActiveKey": "CLIENTS.OPERATORS.LAST_ACTIVE.MONTHS_2"
+    }
   ]
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,6 +52,21 @@ export const routes: Routes = [
     ]
   },
   {
+    path: 'clients',
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: 'operators'
+      },
+      {
+        path: 'operators',
+        loadComponent: () =>
+          import('./clients/pages/operators/operators.page').then((m) => m.ClientsOperatorsPageComponent)
+      }
+    ]
+  },
+  {
     path: 'analytics',
     children: [
       {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -34,7 +34,7 @@ export class AppComponent {
     { label: 'NAV.PARKING', route: '/monitoring/incidents' },
     { label: 'NAV.SPACES', route: '/profiles/overview' },
     { label: 'NAV.SUBSCRIPTIONS', route: '/subscription/overview' },
-    { label: 'NAV.CLIENTS', route: '/iam/login' },
+    { label: 'NAV.CLIENTS', route: '/clients/operators' },
     { label: 'NAV.REPORTS', route: '/analytics/overview' }
   ];
 

--- a/src/app/clients/models/operator.model.ts
+++ b/src/app/clients/models/operator.model.ts
@@ -1,0 +1,11 @@
+export type OperatorRole = 'admin' | 'operator';
+export type OperatorStatus = 'active' | 'inactive';
+
+export interface Operator {
+  id: number;
+  name: string;
+  email: string;
+  role: OperatorRole;
+  status: OperatorStatus;
+  lastActiveKey: string;
+}

--- a/src/app/clients/pages/operators/operators.page.css
+++ b/src/app/clients/pages/operators/operators.page.css
@@ -1,0 +1,383 @@
+:host {
+  display: block;
+}
+
+.operators {
+  min-height: calc(100vh - 72px);
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: clamp(1.5rem, 2.5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.operators__header,
+.operators__content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.operators__eyebrow,
+.operators__dialog-eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #60a5fa;
+}
+
+.operators__title,
+.operators__content-header h2 {
+  margin: 0;
+  font-weight: 600;
+}
+
+.operators__title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.operators__content-header h2 {
+  font-size: 1.2rem;
+  color: #f8fafc;
+}
+
+.operators__content-header p {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.operators__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.operators__search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+.operators__search input {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  width: 200px;
+  min-width: 0;
+  outline: none;
+}
+
+.operators__search input::placeholder {
+  color: rgba(203, 213, 225, 0.55);
+}
+
+.operators__cta,
+.operators__ghost,
+.operators__submit,
+.operators__dialog-close,
+.operators__action {
+  border: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.operators__cta,
+.operators__submit {
+  border-radius: 0.75rem;
+  font-weight: 600;
+  padding: 0.7rem 1.4rem;
+  color: #f8fafc;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  transition: filter 0.2s ease;
+}
+
+.operators__cta:hover,
+.operators__cta:focus-visible,
+.operators__submit:hover,
+.operators__submit:focus-visible {
+  filter: brightness(1.05);
+}
+
+.operators__cta:focus-visible,
+.operators__submit:focus-visible,
+.operators__ghost:focus-visible,
+.operators__dialog-close:focus-visible,
+.operators__action:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 3px;
+}
+
+.operators__content {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  padding: clamp(1.5rem, 2vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.operators__table-wrapper {
+  overflow-x: auto;
+}
+
+.operators__table {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+}
+
+.operators__table thead {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.operators__table th,
+.operators__table td {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  border-top: 1px solid rgba(71, 85, 105, 0.35);
+  font-size: 0.95rem;
+}
+
+.operators__table th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  border-top: 0;
+}
+
+.operators__table tr:hover td {
+  background: rgba(30, 41, 59, 0.45);
+}
+
+.operators__table-actions {
+  text-align: right;
+  width: 56px;
+}
+
+.operators__actions {
+  position: relative;
+  display: inline-flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.operators__action {
+  background: none;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.operators__menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 180px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.5);
+  z-index: 10;
+}
+
+.operators__menu-item {
+  width: 100%;
+  background: none;
+  border: 0;
+  color: #f8fafc;
+  text-align: left;
+  padding: 0.65rem 1rem;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.operators__menu-item:hover,
+.operators__menu-item:focus-visible {
+  background: rgba(248, 113, 113, 0.15);
+}
+
+.operators__menu-item[disabled] {
+  color: rgba(148, 163, 184, 0.5);
+  cursor: not-allowed;
+}
+
+.operators__menu-item[disabled]:hover,
+.operators__menu-item[disabled]:focus-visible {
+  background: none;
+}
+
+.operators__role,
+.operators__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.operators__role {
+  background: rgba(59, 130, 246, 0.16);
+  color: #93c5fd;
+}
+
+.operators__role[data-role='admin'] {
+  background: rgba(8, 145, 178, 0.2);
+  color: #67e8f9;
+}
+
+.operators__status[data-status='active'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+
+.operators__status[data-status='inactive'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fca5a5;
+}
+
+.operators__empty {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.operators__dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.78);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 20;
+}
+
+.operators__dialog-content {
+  width: min(420px, 100%);
+  background: #0b1220;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.operators__dialog-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.operators__dialog-close {
+  align-self: flex-start;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  color: #e2e8f0;
+}
+
+.operators__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.operators__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.operators__field label {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.operators__field input {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  font: inherit;
+}
+
+.operators__field input:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.operators__role-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.operators__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #fca5a5;
+}
+
+.operators__form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.operators__ghost {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 0.75rem;
+  color: #cbd5f5;
+  padding: 0.65rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.operators__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 720px) {
+  .operators {
+    padding: 1.75rem;
+  }
+
+  .operators__search input {
+    width: 100%;
+  }
+
+  .operators__table {
+    min-width: 100%;
+  }
+
+  .operators__toolbar {
+    width: 100%;
+  }
+
+  .operators__cta {
+    width: 100%;
+  }
+}

--- a/src/app/clients/pages/operators/operators.page.html
+++ b/src/app/clients/pages/operators/operators.page.html
@@ -1,0 +1,142 @@
+<section class="operators">
+  <header class="operators__header">
+    <div>
+      <p class="operators__eyebrow">{{ 'CLIENTS.OPERATORS.EYEBROW' | translate }}</p>
+      <h1 class="operators__title">{{ 'CLIENTS.OPERATORS.TITLE' | translate }}</h1>
+    </div>
+    <div class="operators__toolbar" role="search">
+      <label class="operators__search" [attr.aria-label]="'CLIENTS.OPERATORS.SEARCH_LABEL' | translate">
+        <span aria-hidden="true">🔍</span>
+        <input
+          type="search"
+          [placeholder]="'CLIENTS.OPERATORS.SEARCH_PLACEHOLDER' | translate"
+          (input)="onSearch($any($event.target).value)"
+        />
+      </label>
+      <button type="button" class="operators__cta" (click)="openForm()">
+        {{ 'CLIENTS.OPERATORS.NEW_OPERATOR' | translate }}
+      </button>
+    </div>
+  </header>
+
+  <section class="operators__content" aria-labelledby="operators-list-title">
+    <div class="operators__content-header">
+      <h2 id="operators-list-title">{{ 'CLIENTS.OPERATORS.ALL_OPERATORS' | translate }}</h2>
+      <p>{{ 'CLIENTS.OPERATORS.ALL_OPERATORS_DESCRIPTION' | translate }}</p>
+    </div>
+
+    <div class="operators__table-wrapper" role="region" [attr.aria-label]="'CLIENTS.OPERATORS.TABLE_LABEL' | translate">
+      <table class="operators__table">
+        <thead>
+          <tr>
+            <th scope="col">{{ 'CLIENTS.OPERATORS.COLUMNS.NAME' | translate }}</th>
+            <th scope="col">{{ 'CLIENTS.OPERATORS.COLUMNS.EMAIL' | translate }}</th>
+            <th scope="col">{{ 'CLIENTS.OPERATORS.COLUMNS.ROLE' | translate }}</th>
+            <th scope="col">{{ 'CLIENTS.OPERATORS.COLUMNS.STATUS' | translate }}</th>
+            <th scope="col">{{ 'CLIENTS.OPERATORS.COLUMNS.LAST_ACTIVE' | translate }}</th>
+            <th scope="col" class="operators__table-actions">{{ 'CLIENTS.OPERATORS.COLUMNS.ACTIONS' | translate }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let operator of filteredOperators(); trackBy: trackById">
+            <td data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.NAME' | translate }}">{{ operator.name }}</td>
+            <td data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.EMAIL' | translate }}">{{ operator.email }}</td>
+            <td data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.ROLE' | translate }}">
+              <span class="operators__role" [attr.data-role]="operator.role">
+                {{ 'CLIENTS.OPERATORS.ROLES.' + (operator.role | uppercase) | translate }}
+              </span>
+            </td>
+            <td data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.STATUS' | translate }}">
+              <span class="operators__status" [attr.data-status]="operator.status">
+                {{ 'CLIENTS.OPERATORS.STATUS.' + (operator.status | uppercase) | translate }}
+              </span>
+            </td>
+            <td data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.LAST_ACTIVE' | translate }}">
+              {{ operator.lastActiveKey | translate }}
+            </td>
+            <td class="operators__table-actions" data-title="{{ 'CLIENTS.OPERATORS.COLUMNS.ACTIONS' | translate }}">
+              <div class="operators__actions" (click)="$event.stopPropagation()">
+                <button
+                  type="button"
+                  class="operators__action"
+                  [attr.aria-label]="'CLIENTS.OPERATORS.ACTIONS.MORE' | translate"
+                  (click)="toggleMenu(operator.id)"
+                >
+                  ⋯
+                </button>
+                <div
+                  *ngIf="menuOpenFor() === operator.id"
+                  class="operators__menu"
+                  role="menu"
+                  [attr.aria-label]="'CLIENTS.OPERATORS.ACTIONS.MENU_LABEL' | translate"
+                >
+                  <button
+                    type="button"
+                    class="operators__menu-item"
+                    role="menuitem"
+                    [disabled]="operator.role !== 'operator'"
+                    (click)="deleteOperator(operator)"
+                  >
+                    {{ 'CLIENTS.OPERATORS.ACTIONS.DELETE' | translate }}
+                  </button>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p *ngIf="filteredOperators().length === 0" class="operators__empty">{{ 'CLIENTS.OPERATORS.EMPTY_STATE' | translate }}</p>
+    </div>
+  </section>
+
+  <div *ngIf="showForm()" class="operators__dialog" role="dialog" aria-modal="true" [attr.aria-labelledby]="'new-operator-title'">
+    <div class="operators__dialog-content">
+      <header class="operators__dialog-header">
+        <div>
+          <p class="operators__dialog-eyebrow">{{ 'CLIENTS.OPERATORS.DIALOG.EYEBROW' | translate }}</p>
+          <h2 id="new-operator-title">{{ 'CLIENTS.OPERATORS.DIALOG.TITLE' | translate }}</h2>
+        </div>
+        <button type="button" class="operators__dialog-close" (click)="closeForm()" [attr.aria-label]="'CLIENTS.OPERATORS.DIALOG.CLOSE' | translate">
+          ✕
+        </button>
+      </header>
+
+      <form [formGroup]="operatorForm" (ngSubmit)="submit()" class="operators__form">
+        <div class="operators__field">
+          <label for="operator-name">{{ 'CLIENTS.OPERATORS.FORM.NAME' | translate }}</label>
+          <input id="operator-name" type="text" formControlName="name" [attr.placeholder]="'CLIENTS.OPERATORS.FORM.NAME_PLACEHOLDER' | translate" />
+          <p *ngIf="operatorForm.controls.name.touched && operatorForm.controls.name.invalid" class="operators__error">
+            {{ 'CLIENTS.OPERATORS.FORM.NAME_ERROR' | translate }}
+          </p>
+        </div>
+
+        <div class="operators__field">
+          <label for="operator-email">{{ 'CLIENTS.OPERATORS.FORM.EMAIL' | translate }}</label>
+          <input
+            id="operator-email"
+            type="email"
+            formControlName="email"
+            [attr.placeholder]="'CLIENTS.OPERATORS.FORM.EMAIL_PLACEHOLDER' | translate"
+          />
+          <p *ngIf="operatorForm.controls.email.touched && operatorForm.controls.email.invalid" class="operators__error">
+            {{ 'CLIENTS.OPERATORS.FORM.EMAIL_ERROR' | translate }}
+          </p>
+        </div>
+
+        <div class="operators__field">
+          <label>{{ 'CLIENTS.OPERATORS.FORM.ROLE' | translate }}</label>
+          <p class="operators__role-hint">{{ 'CLIENTS.OPERATORS.FORM.ROLE_HINT' | translate }}</p>
+        </div>
+
+        <div class="operators__form-actions">
+          <button type="button" class="operators__ghost" (click)="closeForm()">
+            {{ 'CLIENTS.OPERATORS.FORM.CANCEL' | translate }}
+          </button>
+          <button type="submit" class="operators__submit" [disabled]="operatorForm.invalid || isSubmitting()">
+            {{ 'CLIENTS.OPERATORS.FORM.SUBMIT' | translate }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</section>

--- a/src/app/clients/pages/operators/operators.page.ts
+++ b/src/app/clients/pages/operators/operators.page.ts
@@ -1,0 +1,148 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  HostListener,
+  OnInit,
+  computed,
+  inject,
+  signal
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import { Operator } from '../../models/operator.model';
+import { OperatorsService } from '../../services/operators.service';
+
+@Component({
+  selector: 'app-clients-operators-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslateModule],
+  templateUrl: './operators.page.html',
+  styleUrls: ['./operators.page.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ClientsOperatorsPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly operatorsService = inject(OperatorsService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly operators = signal<Operator[]>([]);
+  readonly searchTerm = signal('');
+  readonly showForm = signal(false);
+  readonly isSubmitting = signal(false);
+  readonly menuOpenFor = signal<number | null>(null);
+
+  readonly operatorForm = this.fb.nonNullable.group({
+    name: ['', [Validators.required, Validators.maxLength(80)]],
+    email: ['', [Validators.required, Validators.email]]
+  });
+
+  readonly filteredOperators = computed(() => {
+    const term = this.searchTerm().trim().toLowerCase();
+
+    if (!term) {
+      return this.operators();
+    }
+
+    return this.operators().filter((operator) => {
+      const haystack = `${operator.name} ${operator.email}`.toLowerCase();
+      return haystack.includes(term);
+    });
+  });
+
+  readonly trackById = (_: number, operator: Operator) => operator.id;
+
+  ngOnInit(): void {
+    this.loadOperators();
+  }
+
+  @HostListener('document:click', ['$event'])
+  closeMenuOnOutsideClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (!target?.closest('.operators__actions')) {
+      this.menuOpenFor.set(null);
+    }
+  }
+
+  onSearch(term: string): void {
+    this.searchTerm.set(term);
+  }
+
+  openForm(): void {
+    this.showForm.set(true);
+  }
+
+  closeForm(): void {
+    this.operatorForm.reset({ name: '', email: '' });
+    this.showForm.set(false);
+    this.isSubmitting.set(false);
+  }
+
+  submit(): void {
+    if (this.operatorForm.invalid) {
+      this.operatorForm.markAllAsTouched();
+      return;
+    }
+
+    const { name, email } = this.operatorForm.getRawValue();
+
+    this.isSubmitting.set(true);
+
+    this.operatorsService
+      .createOperator({ name, email })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (operator) => {
+          this.operators.update((current) => {
+            const updated = [operator, ...current];
+            return updated.sort((a, b) => b.id - a.id);
+          });
+          this.closeForm();
+        },
+        error: (error) => {
+          console.error('Failed to create operator', error);
+          this.isSubmitting.set(false);
+        }
+      });
+  }
+
+  toggleMenu(operatorId: number): void {
+    this.menuOpenFor.update((current) => (current === operatorId ? null : operatorId));
+  }
+
+  deleteOperator(operator: Operator): void {
+    if (operator.role !== 'operator') {
+      return;
+    }
+
+    this.operatorsService
+      .deleteOperator(operator.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.operators.update((current) => current.filter((item) => item.id !== operator.id));
+          this.menuOpenFor.set(null);
+        },
+        error: (error) => {
+          console.error('Failed to delete operator', error);
+          this.menuOpenFor.set(null);
+        }
+      });
+  }
+
+  private loadOperators(): void {
+    this.operatorsService
+      .getOperators()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (operators) => {
+          const sorted = [...operators].sort((a, b) => b.id - a.id);
+          this.operators.set(sorted);
+        },
+        error: (error) => console.error('Failed to load operators', error)
+      });
+  }
+}

--- a/src/app/clients/services/operators.service.ts
+++ b/src/app/clients/services/operators.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { BaseService } from '../../shared/services/base.service';
+import { Operator } from '../models/operator.model';
+
+interface CreateOperatorPayload {
+  name: string;
+  email: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class OperatorsService extends BaseService {
+  getOperators(): Observable<Operator[]> {
+    return this.get<Operator[]>('api/v1/operators');
+  }
+
+  createOperator(payload: CreateOperatorPayload): Observable<Operator> {
+    const body: Omit<Operator, 'id'> = {
+      ...payload,
+      role: 'operator',
+      status: 'active',
+      lastActiveKey: 'CLIENTS.OPERATORS.LAST_ACTIVE.JUST_NOW'
+    };
+
+    return this.http.post<Operator>(`${this.apiUrl}/api/v1/operators`, body);
+  }
+
+  deleteOperator(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/api/v1/operators/${id}`);
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -84,6 +84,66 @@
       "TITLE": "Available plans"
     }
   },
+  "CLIENTS": {
+    "OPERATORS": {
+      "EYEBROW": "Team directory",
+      "TITLE": "Operators",
+      "SEARCH_LABEL": "Filter operators",
+      "SEARCH_PLACEHOLDER": "Search operators",
+      "NEW_OPERATOR": "New operator",
+      "ALL_OPERATORS": "All operators",
+      "ALL_OPERATORS_DESCRIPTION": "Manage administrator and operator access for EasyPark.",
+      "TABLE_LABEL": "Operators table",
+      "COLUMNS": {
+        "NAME": "Name",
+        "EMAIL": "Email",
+        "ROLE": "Role",
+        "STATUS": "Status",
+        "LAST_ACTIVE": "Last active",
+        "ACTIONS": "Actions"
+      },
+      "ACTIONS": {
+        "MORE": "More actions",
+        "MENU_LABEL": "Operator actions",
+        "DELETE": "Delete operator"
+      },
+      "ROLES": {
+        "ADMIN": "Admin",
+        "OPERATOR": "Operator"
+      },
+      "STATUS": {
+        "ACTIVE": "Active",
+        "INACTIVE": "Inactive"
+      },
+      "LAST_ACTIVE": {
+        "DAY_1": "1 day ago",
+        "DAYS_2": "2 days ago",
+        "DAYS_4": "4 days ago",
+        "HOURS_6": "6 hours ago",
+        "MONTHS_2": "2 months ago",
+        "WEEKS_1": "1 week ago",
+        "JUST_NOW": "Just now"
+      },
+      "EMPTY_STATE": "No operators match your search.",
+      "DIALOG": {
+        "EYEBROW": "Add operator",
+        "TITLE": "New operator",
+        "CLOSE": "Close dialog"
+      },
+      "FORM": {
+        "NAME": "Full name",
+        "NAME_PLACEHOLDER": "Enter full name",
+        "NAME_ERROR": "Please provide a name.",
+        "EMAIL": "Email",
+        "EMAIL_PLACEHOLDER": "name@example.com",
+        "EMAIL_ERROR": "Enter a valid email address.",
+        "ROLE": "Role",
+        "ROLE_HINT": "New team members are created as operators. Administrators can be updated later from the table.",
+        "CANCEL": "Cancel",
+        "SUBMIT": "Add operator"
+      }
+    }
+  },
   "ANALYTICS": {
     "OVERVIEW": {
       "TITLE": "Analytics",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -84,6 +84,66 @@
       "TITLE": "Planes disponibles"
     }
   },
+  "CLIENTS": {
+    "OPERATORS": {
+      "EYEBROW": "Directorio de equipo",
+      "TITLE": "Operadores",
+      "SEARCH_LABEL": "Filtrar operadores",
+      "SEARCH_PLACEHOLDER": "Buscar operadores",
+      "NEW_OPERATOR": "Nuevo operador",
+      "ALL_OPERATORS": "Todos los operadores",
+      "ALL_OPERATORS_DESCRIPTION": "Administra el acceso de administradores y operadores de EasyPark.",
+      "TABLE_LABEL": "Tabla de operadores",
+      "COLUMNS": {
+        "NAME": "Nombre",
+        "EMAIL": "Correo",
+        "ROLE": "Rol",
+        "STATUS": "Estado",
+        "LAST_ACTIVE": "Última actividad",
+        "ACTIONS": "Acciones"
+      },
+      "ACTIONS": {
+        "MORE": "Más acciones",
+        "MENU_LABEL": "Acciones del operador",
+        "DELETE": "Eliminar operador"
+      },
+      "ROLES": {
+        "ADMIN": "Administrador",
+        "OPERATOR": "Operador"
+      },
+      "STATUS": {
+        "ACTIVE": "Activo",
+        "INACTIVE": "Inactivo"
+      },
+      "LAST_ACTIVE": {
+        "DAY_1": "Hace 1 día",
+        "DAYS_2": "Hace 2 días",
+        "DAYS_4": "Hace 4 días",
+        "HOURS_6": "Hace 6 horas",
+        "MONTHS_2": "Hace 2 meses",
+        "WEEKS_1": "Hace 1 semana",
+        "JUST_NOW": "Hace un momento"
+      },
+      "EMPTY_STATE": "Ningún operador coincide con tu búsqueda.",
+      "DIALOG": {
+        "EYEBROW": "Agregar operador",
+        "TITLE": "Nuevo operador",
+        "CLOSE": "Cerrar diálogo"
+      },
+      "FORM": {
+        "NAME": "Nombre completo",
+        "NAME_PLACEHOLDER": "Ingresa el nombre completo",
+        "NAME_ERROR": "Proporciona un nombre.",
+        "EMAIL": "Correo electrónico",
+        "EMAIL_PLACEHOLDER": "nombre@ejemplo.com",
+        "EMAIL_ERROR": "Ingresa un correo válido.",
+        "ROLE": "Rol",
+        "ROLE_HINT": "Los nuevos miembros se crean como operadores. Puedes actualizarlos luego desde la tabla.",
+        "CANCEL": "Cancelar",
+        "SUBMIT": "Agregar operador"
+      }
+    }
+  },
   "ANALYTICS": {
     "OVERVIEW": {
       "TITLE": "Analítica",


### PR DESCRIPTION
## Summary
- store the initial operators collection in the json-server database and expose a typed client service
- load operators from the API, allow creating new operators, and support deleting operator-role entries from the actions menu
- style the actions popover and extend i18n resources for the new menu strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc5e973b708328ae7b3197cb5c1d37